### PR TITLE
vs2013: fix leak, vs2015+: use unrestricted union

### DIFF
--- a/include/autocheck/value.hpp
+++ b/include/autocheck/value.hpp
@@ -10,27 +10,30 @@ namespace autocheck {
 
   template <typename T>
   class value {
-    private:
+    private:  
+      // Visual Studio before 2015 doesn't support unrestricted unions.
+      // However, if we declare `T object` as a member,
+      // then we must declare the allocation as `Static`,
+      // or else `object` will leak when we start to generate test values.
       enum {
         None,
         Static,
         Heap
       }    allocation =
-
 #if !defined(_MSC_VER) || _MSC_VER >= 1900
                         None;
-
-      union {
 #else
                         Static;
-	  //Visual Studio 2013 doesn't support unrestricted unions
+#endif
+
+#if !defined(_MSC_VER) || _MSC_VER >= 1900
+      union {
 #endif
         T* pointer = nullptr;
         T  object;
 #if !defined(_MSC_VER) || _MSC_VER >= 1900
       };
 #endif
-
 
     public:
       value() {}

--- a/include/autocheck/value.hpp
+++ b/include/autocheck/value.hpp
@@ -15,17 +15,22 @@ namespace autocheck {
         None,
         Static,
         Heap
-      }    allocation = None;
+      }    allocation =
 
-#ifndef _MSC_VER
-      //Visual Studio 2013 doesn't support unrestricted unions
+#if !defined(_MSC_VER) || _MSC_VER >= 1900
+                        None;
+
       union {
+#else
+                        Static;
+	  //Visual Studio 2013 doesn't support unrestricted unions
 #endif
         T* pointer = nullptr;
         T  object;
-#ifndef _MSC_VER
+#if !defined(_MSC_VER) || _MSC_VER >= 1900
       };
 #endif
+
 
     public:
       value() {}


### PR DESCRIPTION
As unrestricted unions are not used for Visual Studio 2013, default
```
T  object;
```
field is created in `value` template class default contructor. But as `allocation` is initialized with `None` this default object leaks, when we start to generate test values. So, for example, there is a memory leak in the following code, if it is compiled by Visual Studio 2013:
```
autocheck::check<std::string>([](const std::string& str) { return true; });
```
Patch fixes this leakage and turns on unrestricted union usage for Visual Studio 2015+.